### PR TITLE
include query params on post/patch/etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+.idea

--- a/lib/MailchimpMarketing/api_client.rb
+++ b/lib/MailchimpMarketing/api_client.rb
@@ -65,7 +65,7 @@ module MailchimpMarketing
       res = nil
       case http_method.to_sym.downcase
       when :post, :put, :patch, :delete
-        res = conn.request(:method => http_method, :body => opts[:body])
+        res = conn.request(:method => http_method, :body => opts[:body], :query => opts[:query_params])
       when :get
         res = conn.get(:query => opts[:query_params])
       end


### PR DESCRIPTION
This PR adds query params into the `conn.request` for post/put/patch, etc requests.